### PR TITLE
Replace net.i2p.crypto with BouncyCastle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'signing'
 }
 
-def jarVersion = "2.0.2"
+def jarVersion = "2.1.0"
 group = 'io.nats'
 
 def isMerge = System.getenv("BUILD_EVENT") == "push"
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'net.i2p.crypto:eddsa:0.3.0'
+    implementation 'org.bouncycastle:bcprov-lts8on:2.73.7'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'
     testImplementation 'com.github.stefanbirkner:system-lambda:1.2.1'

--- a/src/main/java/io/nats/nkey/KeyWrapper.java
+++ b/src/main/java/io/nats/nkey/KeyWrapper.java
@@ -1,0 +1,29 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.nkey;
+
+import java.security.Key;
+
+abstract class KeyWrapper implements Key {
+
+    @Override
+    public String getAlgorithm() {
+        return "EdDSA";
+    }
+
+    @Override
+    public String getFormat() {
+        return "PKCS#8";
+    }
+}

--- a/src/main/java/io/nats/nkey/NKeyConstants.java
+++ b/src/main/java/io/nats/nkey/NKeyConstants.java
@@ -13,9 +13,6 @@
 
 package io.nats.nkey;
 
-import net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec;
-import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
-
 public interface NKeyConstants {
     // PrefixByteSeed is the prefix byte used for encoded NATS Seeds
     int PREFIX_BYTE_SEED = 18 << 3; // Base32-encodes to 'S...'
@@ -41,8 +38,6 @@ public interface NKeyConstants {
     int ED25519_PUBLIC_KEYSIZE = 32;
     int ED25519_PRIVATE_KEYSIZE = 64;
     int ED25519_SEED_SIZE = 32;
-
-    EdDSANamedCurveSpec ED_25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
 
     // XModem CRC based on the go version of NKeys
     int[] CRC_16_TABLE = { 0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7, 0x8108,

--- a/src/main/java/io/nats/nkey/PrivateKeyWrapper.java
+++ b/src/main/java/io/nats/nkey/PrivateKeyWrapper.java
@@ -1,0 +1,32 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.nkey;
+
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
+
+import java.security.PrivateKey;
+
+class PrivateKeyWrapper extends KeyWrapper implements PrivateKey {
+
+    final Ed25519PrivateKeyParameters privateKey;
+
+    public PrivateKeyWrapper(Ed25519PrivateKeyParameters privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        return privateKey.getEncoded();
+    }
+}

--- a/src/main/java/io/nats/nkey/PublicKeyWrapper.java
+++ b/src/main/java/io/nats/nkey/PublicKeyWrapper.java
@@ -1,0 +1,32 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.nkey;
+
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
+
+import java.security.PublicKey;
+
+class PublicKeyWrapper extends KeyWrapper implements PublicKey {
+
+    final Ed25519PublicKeyParameters publicKey;
+
+    public PublicKeyWrapper(Ed25519PublicKeyParameters publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        return publicKey.getEncoded();
+    }
+}


### PR DESCRIPTION
net.i2p.crypto has a CVE https://nvd.nist.gov/vuln/detail/CVE-2020-36843 and is not being maintained. BouncyCastle is an industry standard well maintained library.